### PR TITLE
Improve Error Message for Getting SQL Type

### DIFF
--- a/my-postgres-core/src/sql_value/sql_value_metadata.rs
+++ b/my-postgres-core/src/sql_value/sql_value_metadata.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub struct SqlValueMetadata {
     pub sql_type: Option<&'static str>,
     pub operator: Option<&'static str>,

--- a/my-postgres-core/src/table_schema/sql_type_provider.rs
+++ b/my-postgres-core/src/table_schema/sql_type_provider.rs
@@ -132,7 +132,7 @@ impl SqlTypeProvider for bool {
 
 impl SqlTypeProvider for DateTimeAsMicroseconds {
     fn get_sql_type(metadata: Option<SqlValueMetadata>) -> TableColumnType {
-        if let Some(metadata) = metadata {
+        if let Some(metadata) = &metadata {
             if let Some(sql_type) = metadata.sql_type {
                 if sql_type == "timestamp" {
                     return TableColumnType::Timestamp;
@@ -144,6 +144,6 @@ impl SqlTypeProvider for DateTimeAsMicroseconds {
             }
         }
 
-        panic!("Sql type is not set")
+        panic!("Sql type is not set: {:?}", metadata)
     }
 }


### PR DESCRIPTION
Improves the panic message when the SQL type is not set, providing more context to help diagnose the issue faster.